### PR TITLE
Fix floating point parsing on non-English Windows

### DIFF
--- a/src/OpenSage.DataViewer.Windows/App.xaml.cs
+++ b/src/OpenSage.DataViewer.Windows/App.xaml.cs
@@ -1,9 +1,17 @@
 ﻿using System.Windows;
+using System.Globalization;
+using System.Threading;
 
 namespace OpenSage.DataViewer
 {
     public partial class App : Application
     {
-        
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+
+            base.OnStartup(e);
+        }
     }
 }

--- a/src/OpenSage.DataViewer.Windows/App.xaml.cs
+++ b/src/OpenSage.DataViewer.Windows/App.xaml.cs
@@ -1,17 +1,8 @@
 ﻿using System.Windows;
-using System.Globalization;
-using System.Threading;
 
 namespace OpenSage.DataViewer
 {
     public partial class App : Application
     {
-        protected override void OnStartup(StartupEventArgs e)
-        {
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
-
-            base.OnStartup(e);
-        }
     }
 }

--- a/src/OpenSage.Game/Data/Ini/Parser/IniLexer.cs
+++ b/src/OpenSage.Game/Data/Ini/Parser/IniLexer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using static OpenSage.Data.Utilities.ParseUtility;
 
 namespace OpenSage.Data.Ini.Parser
 {
@@ -241,7 +242,7 @@ namespace OpenSage.Data.Ini.Parser
                 {
                     return new IniToken(tokenType, CurrentPosition)
                     {
-                        FloatValue = float.Parse(numberValue.TrimEnd('f'))
+                        FloatValue = ParseFloat(numberValue.TrimEnd('f'))
                     };
                 }
                 if (hasDot)
@@ -260,7 +261,7 @@ namespace OpenSage.Data.Ini.Parser
                 case IniTokenType.PercentLiteral:
                     return new IniToken(tokenType, pos)
                     {
-                        FloatValue = float.Parse(numberValue)
+                        FloatValue = ParseFloat(numberValue)
                     };
 
                 case IniTokenType.IntegerLiteral:

--- a/src/OpenSage.Game/Data/Utilities/ParseUtility.cs
+++ b/src/OpenSage.Game/Data/Utilities/ParseUtility.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+
+namespace OpenSage.Data.Utilities
+{
+    internal static class ParseUtility
+    {
+        public static float ParseFloat(string s)
+        {
+            return float.Parse(s, CultureInfo.InvariantCulture);
+        }
+
+        public static bool TryParseFloat(string s, out float result)
+        {
+            return float.TryParse(s, out result);
+        }
+    }
+}

--- a/src/OpenSage.Game/Data/Utilities/ParseUtility.cs
+++ b/src/OpenSage.Game/Data/Utilities/ParseUtility.cs
@@ -11,7 +11,7 @@ namespace OpenSage.Data.Utilities
 
         public static bool TryParseFloat(string s, out float result)
         {
-            return float.TryParse(s, out result);
+            return float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
         }
     }
 }

--- a/src/OpenSage.Game/Data/W3d/W3dVertexMapperArgs.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dVertexMapperArgs.cs
@@ -86,11 +86,11 @@ namespace OpenSage.Data.W3d
                 switch (mapperArgName)
                 {
                     case "UPerSec":
-                        result.UPerSec = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UPerSec);
                         break;
 
                     case "VPerSec":
-                        result.VPerSec = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VPerSec);
                         break;
 
                     case "UScale":
@@ -98,11 +98,11 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case "VScale":
-                        result.VScale = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VScale);
                         break;
 
                     case "FPS":
-                        result.FPS = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.FPS);
                         break;
 
                     case "Log1Width":
@@ -118,43 +118,43 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case "Speed":
-                        result.Speed = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.Speed);
                         break;
 
                     case "UCenter":
-                        result.UCenter = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UCenter);
                         break;
 
                     case "VCenter":
-                        result.VCenter = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VCenter);
                         break;
 
                     case "UAmp":
-                        result.UAmp = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UAmp);
                         break;
 
                     case "UFreq":
-                        result.UFreq = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UFreq);
                         break;
 
                     case "UPhase":
-                        result.UPhase = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UPhase);
                         break;
 
                     case "VAmp":
-                        result.VAmp = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VAmp);
                         break;
 
                     case "VFreq":
-                        result.VFreq = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VFreq);
                         break;
 
                     case "VPhase":
-                        result.VPhase = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VPhase);
                         break;
 
                     case "BumpRotation":
-                        result.BumpRotation = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.BumpRotation);
                         break;
 
                     case "BumpScale":
@@ -162,15 +162,15 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case "UStep":
-                        result.UStep = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.UStep);
                         break;
 
                     case "VStep":
-                        result.VStep = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.VStep);
                         break;
 
                     case "SPS":
-                        result.StepsPerSecond = ParseFloat(mapperArgValue);
+                        TryParseFloat(mapperArgValue, out result.StepsPerSecond);
                         break;
 
                     default:

--- a/src/OpenSage.Game/Data/W3d/W3dVertexMapperArgs.cs
+++ b/src/OpenSage.Game/Data/W3d/W3dVertexMapperArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using static OpenSage.Data.Utilities.ParseUtility;
 
 namespace OpenSage.Data.W3d
 {
@@ -85,23 +86,23 @@ namespace OpenSage.Data.W3d
                 switch (mapperArgName)
                 {
                     case "UPerSec":
-                        result.UPerSec = float.Parse(mapperArgValue);
+                        result.UPerSec = ParseFloat(mapperArgValue);
                         break;
 
                     case "VPerSec":
-                        result.VPerSec = float.Parse(mapperArgValue);
+                        result.VPerSec = ParseFloat(mapperArgValue);
                         break;
 
                     case "UScale":
-                        float.TryParse(mapperArgValue, out result.UScale);
+                        TryParseFloat(mapperArgValue, out result.UScale);
                         break;
 
                     case "VScale":
-                        result.VScale = float.Parse(mapperArgValue);
+                        result.VScale = ParseFloat(mapperArgValue);
                         break;
 
                     case "FPS":
-                        result.FPS = float.Parse(mapperArgValue);
+                        result.FPS = ParseFloat(mapperArgValue);
                         break;
 
                     case "Log1Width":
@@ -117,59 +118,59 @@ namespace OpenSage.Data.W3d
                         break;
 
                     case "Speed":
-                        result.Speed = float.Parse(mapperArgValue);
+                        result.Speed = ParseFloat(mapperArgValue);
                         break;
 
                     case "UCenter":
-                        result.UCenter = float.Parse(mapperArgValue);
+                        result.UCenter = ParseFloat(mapperArgValue);
                         break;
 
                     case "VCenter":
-                        result.VCenter = float.Parse(mapperArgValue);
+                        result.VCenter = ParseFloat(mapperArgValue);
                         break;
 
                     case "UAmp":
-                        result.UAmp = float.Parse(mapperArgValue);
+                        result.UAmp = ParseFloat(mapperArgValue);
                         break;
 
                     case "UFreq":
-                        result.UFreq = float.Parse(mapperArgValue);
+                        result.UFreq = ParseFloat(mapperArgValue);
                         break;
 
                     case "UPhase":
-                        result.UPhase = float.Parse(mapperArgValue);
+                        result.UPhase = ParseFloat(mapperArgValue);
                         break;
 
                     case "VAmp":
-                        result.VAmp = float.Parse(mapperArgValue);
+                        result.VAmp = ParseFloat(mapperArgValue);
                         break;
 
                     case "VFreq":
-                        result.VFreq = float.Parse(mapperArgValue);
+                        result.VFreq = ParseFloat(mapperArgValue);
                         break;
 
                     case "VPhase":
-                        result.VPhase = float.Parse(mapperArgValue);
+                        result.VPhase = ParseFloat(mapperArgValue);
                         break;
 
                     case "BumpRotation":
-                        result.BumpRotation = float.Parse(mapperArgValue);
+                        result.BumpRotation = ParseFloat(mapperArgValue);
                         break;
 
                     case "BumpScale":
-                        float.TryParse(mapperArgValue, out result.BumpScale);
+                        TryParseFloat(mapperArgValue, out result.BumpScale);
                         break;
 
                     case "UStep":
-                        result.UStep = float.Parse(mapperArgValue);
+                        result.UStep = ParseFloat(mapperArgValue);
                         break;
 
                     case "VStep":
-                        result.VStep = float.Parse(mapperArgValue);
+                        result.VStep = ParseFloat(mapperArgValue);
                         break;
 
                     case "SPS":
-                        result.StepsPerSecond = float.Parse(mapperArgValue);
+                        result.StepsPerSecond = ParseFloat(mapperArgValue);
                         break;
 
                     default:


### PR DESCRIPTION
`float.Parse` uses the current locale setting of the OS to decide which floating point format to use. This is a problem in countries which use the [decimal comma](https://en.wikipedia.org/wiki/Decimal_mark#Countries_using_Arabic_numerals_with_decimal_comma) (which include the vast majority of European and South American countries).

This PR fixes that issue by making `InvariantCulture` (basically `en-us`) the default culture for the main thread and newly created threads.