### PR TITLE
WIP: Resolve game installation paths from Windows registry

### DIFF
--- a/src/OpenSage.DataViewer.Windows/Bootstrapper.cs
+++ b/src/OpenSage.DataViewer.Windows/Bootstrapper.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using Caliburn.Micro;
 using OpenSage.DataViewer.Framework;
 using OpenSage.DataViewer.ViewModels;
+using OpenSage.Data;
 
 namespace OpenSage.DataViewer
 {
@@ -28,6 +29,7 @@ namespace OpenSage.DataViewer
             container = new SimpleContainer();
 
             container.Singleton<IWindowManager, WindowManager>();
+            container.Singleton<IInstallationLocator, RegistryInstallationLocator>();
             container.Instance(_graphicsDeviceManager);
             container.Instance(_gameService);
 

--- a/src/OpenSage.DataViewer/ViewModels/ShellViewModel.cs
+++ b/src/OpenSage.DataViewer/ViewModels/ShellViewModel.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
 using Caliburn.Micro;
 using OpenSage.DataViewer.Framework;
+using OpenSage.Data;
 
 namespace OpenSage.DataViewer.ViewModels
 {
@@ -38,18 +37,11 @@ namespace OpenSage.DataViewer.ViewModels
 
         private static IEnumerable<InstallationViewModel> FindInstallations()
         {
-            var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            var locator = IoC.Get<IInstallationLocator>();
 
-            var possibleInstallations = new[]
-            {
-                new InstallationViewModel("C&C Generals (The First Decade)", Path.Combine(programFilesPath, @"EA Games\Command & Conquer The First Decade\Command & Conquer(tm) Generals")),
-                new InstallationViewModel("C&C Generals (Origin)", Path.Combine(programFilesPath, @"Origin Games\Command and Conquer Generals Zero Hour\Command and Conquer Generals")),
-                new InstallationViewModel("C&C Generals Zero Hour (The First Decade)", Path.Combine(programFilesPath, @"EA Games\Command & Conquer The First Decade\Command & Conquer(tm) Generals Zero Hour")),
-                new InstallationViewModel("C&C Generals Zero Hour (Origin)", Path.Combine(programFilesPath, @"Origin Games\Command and Conquer Generals Zero Hour\Command and Conquer Generals Zero Hour")),
-                new InstallationViewModel("Battle for Middle-earth (DVD)", Path.Combine(programFilesPath, @"EA Games\The Battle for Middle-earth (tm)"))
-            };
-
-            return possibleInstallations.Where(x => Directory.Exists(x.Path));
+            return Games.GetAll()
+                .SelectMany(locator.FindInstallations)
+                .Select(installation => new InstallationViewModel(installation.DisplayName, installation.Path));
         }
     }
 }

--- a/src/OpenSage.DataViewer/ViewModels/ShellViewModel.cs
+++ b/src/OpenSage.DataViewer/ViewModels/ShellViewModel.cs
@@ -39,7 +39,7 @@ namespace OpenSage.DataViewer.ViewModels
         {
             var locator = IoC.Get<IInstallationLocator>();
 
-            return Games.GetAll()
+            return SageGames.GetAll()
                 .SelectMany(locator.FindInstallations)
                 .Select(installation => new InstallationViewModel(installation.DisplayName, installation.Path));
         }

--- a/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
+++ b/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
@@ -6,7 +6,12 @@ namespace OpenSage.Data.Tests.Big
 {
     public class BigArchiveTests
     {
-        private const string BigFilePath = @"C:\Program Files (x86)\Origin Games\Command and Conquer Generals Zero Hour\Command and Conquer Generals Zero Hour\W3DZH.big";
+        private string BigFilePath;
+
+        public BigArchiveTests()
+        {
+            BigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(GameId.ZeroHour), "W3DZH.big");
+        }
 
         [Fact]
         public void OpenBigArchive()

--- a/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
+++ b/src/OpenSage.Game.Tests/Big/BigArchiveTests.cs
@@ -10,7 +10,7 @@ namespace OpenSage.Data.Tests.Big
 
         public BigArchiveTests()
         {
-            BigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(GameId.ZeroHour), "W3DZH.big");
+            BigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.CncGeneralsZeroHour), "W3DZH.big");
         }
 
         [Fact]

--- a/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
+++ b/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
@@ -14,7 +14,7 @@ namespace OpenSage.Data.Tests
             Locator = new RegistryInstallationLocator();
         }
 
-        public static string GetInstallationDirectory(SageGame game) => Locator.FindInstallations(game).FirstOrDefault().Path;
+        public static string GetInstallationDirectory(SageGame game) => Locator.FindInstallations(game).First().Path;
 
         public static void ReadFiles(string fileExtension, ITestOutputHelper output, Action<FileSystemEntry> processFileCallback)
         {

--- a/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
+++ b/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
@@ -7,18 +7,18 @@ namespace OpenSage.Data.Tests
 {
     internal static class InstalledFilesTestData
     {
-        private static readonly IInstallationLocator locator;
+        private static readonly IInstallationLocator Locator;
 
         static InstalledFilesTestData()
         {
-            locator = new RegistryInstallationLocator();
+            Locator = new RegistryInstallationLocator();
         }
 
-        public static string GetInstallationDirectory(GameId game) => locator.FindInstallations(game).FirstOrDefault().Path;
+        public static string GetInstallationDirectory(SageGame game) => Locator.FindInstallations(game).FirstOrDefault().Path;
 
         public static void ReadFiles(string fileExtension, ITestOutputHelper output, Action<FileSystemEntry> processFileCallback)
         {
-            var rootDirectories = Games.GetAll().SelectMany(locator.FindInstallations).Select(i => i.Path);
+            var rootDirectories = SageGames.GetAll().SelectMany(Locator.FindInstallations).Select(i => i.Path);
 
             var foundAtLeastOneFile = false;
             foreach (var rootDirectory in rootDirectories.Where(x => Directory.Exists(x)))

--- a/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
+++ b/src/OpenSage.Game.Tests/InstalledFilesTestData.cs
@@ -7,15 +7,18 @@ namespace OpenSage.Data.Tests
 {
     internal static class InstalledFilesTestData
     {
+        private static readonly IInstallationLocator locator;
+
+        static InstalledFilesTestData()
+        {
+            locator = new RegistryInstallationLocator();
+        }
+
+        public static string GetInstallationDirectory(GameId game) => locator.FindInstallations(game).FirstOrDefault().Path;
+
         public static void ReadFiles(string fileExtension, ITestOutputHelper output, Action<FileSystemEntry> processFileCallback)
         {
-            var rootDirectories = new[]
-            {
-                //@"C:\Program Files (x86)\EA Games\Command & Conquer The First Decade\Command & Conquer(tm) Generals",
-                //@"C:\Program Files (x86)\EA Games\Command & Conquer The First Decade\Command & Conquer(tm) Generals Zero Hour",
-                //@"C:\Program Files (x86)\EA Games\The Battle for Middle-earth (tm)",
-                @"C:\Program Files (x86)\Electronic Arts\The Battle for Middle-earth (tm) II"
-            };
+            var rootDirectories = Games.GetAll().SelectMany(locator.FindInstallations).Select(i => i.Path);
 
             var foundAtLeastOneFile = false;
             foreach (var rootDirectory in rootDirectories.Where(x => Directory.Exists(x)))

--- a/src/OpenSage.Game.Tests/W3d/W3dFileTests.cs
+++ b/src/OpenSage.Game.Tests/W3d/W3dFileTests.cs
@@ -105,7 +105,7 @@ namespace OpenSage.Data.Tests.W3d
         [Fact]
         public void LoadW3dFromBigFile()
         {
-            var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(GameId.ZeroHour), "W3DZH.big");
+            var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(SageGame.CncGeneralsZeroHour), "W3DZH.big");
         
             using (var bigStream = File.OpenRead(bigFilePath))
             using (var bigArchive = new BigArchive(bigStream))

--- a/src/OpenSage.Game.Tests/W3d/W3dFileTests.cs
+++ b/src/OpenSage.Game.Tests/W3d/W3dFileTests.cs
@@ -105,7 +105,7 @@ namespace OpenSage.Data.Tests.W3d
         [Fact]
         public void LoadW3dFromBigFile()
         {
-            const string bigFilePath = @"C:\Program Files (x86)\Origin Games\Command and Conquer Generals Zero Hour\Command and Conquer Generals Zero Hour\W3DZH.big";
+            var bigFilePath = Path.Combine(InstalledFilesTestData.GetInstallationDirectory(GameId.ZeroHour), "W3DZH.big");
         
             using (var bigStream = File.OpenRead(bigFilePath))
             using (var bigArchive = new BigArchive(bigStream))

--- a/src/OpenSage.Game/Data/Ini/AddedInAttribute.cs
+++ b/src/OpenSage.Game/Data/Ini/AddedInAttribute.cs
@@ -12,11 +12,4 @@ namespace OpenSage.Data.Ini
             Game = game;
         }
     }
-
-    public enum SageGame
-    {
-        CncGenerals,
-        CncGeneralsZeroHour,
-        BattleForMiddleEarth
-    }
 }

--- a/src/OpenSage.Game/Data/InstallationLocator.cs
+++ b/src/OpenSage.Game/Data/InstallationLocator.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenSage.Data
+{
+    public enum GameId
+    {
+        Generals,
+        ZeroHour
+    }
+
+    public struct GameInstallation
+    {
+        public readonly GameId Game;
+        public readonly string Path;
+
+        public GameInstallation(GameId game, string path)
+        {
+            Game = game;
+            Path = path;
+        }
+
+        public string DisplayName => GetDisplayName(Game);
+
+        private static string GetDisplayName(GameId game)
+        {
+            switch (game)
+            {
+                case GameId.Generals: return "C&C Generals";
+                case GameId.ZeroHour: return "C&C Generals Zero Hour";
+            }
+
+            throw new ArgumentException($"{game} is not supported.", nameof(game));
+        }
+    }
+
+    public static class Games
+    {
+        public static IEnumerable<GameId> GetAll()
+        {
+            yield return GameId.Generals;
+            yield return GameId.ZeroHour;
+        }
+    }
+
+    public interface IInstallationLocator
+    {
+        IEnumerable<GameInstallation> FindInstallations(GameId game);
+    }
+
+    public class RegistryInstallationLocator : IInstallationLocator
+    {
+        private static readonly (string, string)[] GeneralsKeys = new[] { (@"SOFTWARE\Electronic Arts\EA Games\Generals", "InstallPath") };
+        private static readonly (string, string)[] ZeroHourKeys = new[] { (@"SOFTWARE\Electronic Arts\EA Games\Command and Conquer Generals Zero Hour", "InstallPath") };
+
+        private IEnumerable<(string keyName, string valueName)> GetRegistryKeysForGame(GameId game)
+        {
+            switch (game)
+            {
+                case GameId.Generals: return GeneralsKeys;
+                case GameId.ZeroHour: return ZeroHourKeys;
+                default: return Enumerable.Empty<(string, string)>();
+            }
+        }
+
+        private string GetRegistryValue(string keyName, string valueName)
+        {
+            // 64-bit Windows uses a separate registry for 32-bit and 64-bit applications.
+            // On a 64-bit system Registry.GetValue uses the 64-bit registry by default, which is why we have to read the value the "long way".
+            using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            {
+                using (var key = baseKey.OpenSubKey(keyName, false))
+                {
+                    var path = key.GetValue(valueName, null) as string;
+                    if (path == null) return null;
+
+                    return path;
+                }
+            }
+        }
+
+        public IEnumerable<GameInstallation> FindInstallations(GameId game)
+        {
+            var keys = GetRegistryKeysForGame(game);
+
+            var installations = keys
+                .Select(k => GetRegistryValue(k.keyName, k.valueName))
+                .Where(Directory.Exists)
+                .Select(p => new GameInstallation(game, p))
+                .ToList();
+
+            return installations;
+        }
+    }
+}

--- a/src/OpenSage.Game/SageGame.cs
+++ b/src/OpenSage.Game/SageGame.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace OpenSage
+{
+    public enum SageGame
+    {
+        CncGenerals,
+        CncGeneralsZeroHour,
+        BattleForMiddleEarth
+    }
+
+    public static class SageGames
+    {
+        public static IEnumerable<SageGame> GetAll()
+        {
+            yield return SageGame.CncGenerals;
+            yield return SageGame.CncGeneralsZeroHour;
+        }
+    }
+}


### PR DESCRIPTION
This is a work in progress implementation of a registry-based installation folder resolver, as mentioned in #4. The core feature is functional, and I'm now able to run the data viewer on my computer and access the data from Origin copies of Generals & Zero Hour. There is still some work to be done - see the checklist below and the self-review comments.

- [x] Use an installation locator for tests (resolves #4)
- [ ] Add registry keys for BFME & BFME 2